### PR TITLE
Feature: Toolbar on top

### DIFF
--- a/App/app.html
+++ b/App/app.html
@@ -195,6 +195,7 @@
 			<input type="checkbox" id="show-notifications" checked><label for="show-notifications">Show notifications</label>
 			<input type="checkbox" id="auto-instapaperizer"><label for="auto-instapaperizer">Auto Instapaper</label>
 			<input type="checkbox" id="night-mode"><label for="night-mode">Night Mode</label>
+			<input type="checkbox" id="top-toolbar"><label for="top-toolbar">Toolbar on top</label>
 			<input type="checkbox" id="remember-last-feed" checked><label for="remember-last-feed">Remember Last Feed</label>
 		</div>
 	</div>

--- a/App/css/style.css
+++ b/App/css/style.css
@@ -21,9 +21,8 @@ input, textarea { font-family: "Ubuntu", "Helvetica", "Arial", sans-serif; }
 #app { overflow: hidden; width: 100%; }
 #app > .vsplitbar { width: 1px; cursor: col-resize; background: #afaeac; }
 
-#right-side > .vsplitbar { width: 1px; cursor: col-resize; background: white; border-left: 1px solid #e1e1df; border-right: 3px solid #faf9f7; position: relative; }
+#right-side > .vsplitbar { width: 1px; background: #afaeac; border: 0; cursor: col-resize; border-left: 0px; border-right: 0px; }
 #right-side > .vsplitbar:after { content: ""; position: absolute; display: block; top: auto; bottom: 0; left: 0; right: auto; width: 4px; height: 35px; background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0.08) 0%, rgba(255, 255, 255, 0.08) 100%); border-top: 1px solid rgba(0, 0, 0, 0.2); }
-
 #feeds-column { height: 100%; width: 200px; min-width: 20px; background: url(../images/feeds_bg.png); }
 #feeds-column * { -webkit-user-select: none; }
 #feeds-column ul { margin: 0; padding: 0; }

--- a/App/css/toptoolbar.css
+++ b/App/css/toptoolbar.css
@@ -1,0 +1,13 @@
+#feeds-column #filters { top: 35px; bottom: 0 }
+#feeds-column #feeds { top: 136px; bottom: 0; }
+
+#articles-column #articles { top: 35px; bottom: 0; }
+#post-column #post-window { top: 35px; bottom: 0; }
+
+.bar { top: 0; bottom: 0; border-top: 0; border-bottom: 1px solid rgba(0, 0, 0, 0.2); }
+
+.scope:after, .scope:before { top: 35px; bottom: 0px; -webkit-transform: rotate(180deg);}
+.scope:before { border-bottom-color: #d6d4d4; border-width: 10px; left: 50%; margin-left: -10px; }
+.scope:after { border-bottom-color: #b9b8b8; border-width: 11px; left: 50%; margin-left: -11px; }
+
+#articles .splitter:first-child { margin-top: 0; margin-bottom: 1px; }

--- a/App/scripts/app.js
+++ b/App/scripts/app.js
@@ -37,6 +37,7 @@ function default_settings() {
 		notifications: true,
 		autoInstapaperizer: false,
 		nightMode: false,
+		topToolbar: false,
 		rememberLastFeed: true,
 		lastFeed: false,
 		label: {}
@@ -196,6 +197,7 @@ $(function() {
 			notifications: $('#show-notifications'),
 			autoInstapaperizer: $('#auto-instapaperizer'),
 			nightMode: $('#night-mode'),
+			topToolbar: $('#top-toolbar'),
 			rememberLastFeed: $('#remember-last-feed'),
 			max: {
 				special: $('#max-special'),
@@ -624,6 +626,9 @@ $(function() {
 	})
 	$$.settings.nightMode.on('change', function() {
 		ui.nightMode($(this).prop('checked'))
+	})
+	$$.settings.topToolbar.on('change', function() {
+		ui.topToolbar($(this).prop('checked'))
 	})
 	$$.settings.rememberLastFeed.on('change', function() {
 		settings.rememberLastFeed = $(this).prop('checked')

--- a/App/scripts/app/ui.js
+++ b/App/scripts/app/ui.js
@@ -1281,9 +1281,11 @@ ui = {
 		$$.settings.max.read.val(settings.max.read)
 		$$.settings.autoInstapaperizer.prop('checked', settings.autoInstapaperizer)
 		$$.settings.nightMode.prop('checked', settings.nightMode)
+		$$.settings.topToolbar.prop('checked', settings.topToolbar)
 		$$.settings.rememberLastFeed.prop('checked', settings.rememberLastFeed)
 		core.refreshOnTimer()
 		ui.nightMode()
+		ui.topToolbar()
 	},
 
 	pocket: function() {
@@ -1338,6 +1340,22 @@ ui = {
 		} else {
 			// Disable nightmode
 			$('head .night-mode').remove()
+		}
+	},
+	topToolbar: function(status) {
+		if (status === undefined) {
+			status = settings.topToolbar
+		} else {
+			settings.topToolbar = status
+			storage.savePrefs()
+		}
+
+		if (status) {
+			// Enable nightmode
+			$('head').append('<link class="top-toolbar" rel="stylesheet" href="css/toptoolbar.css">')
+		} else {
+			// Disable nightmode
+			$('head .top-toolbar').remove()
 		}
 	}
 }


### PR DESCRIPTION
As a Gnome Shell user, I've got used to default Gnome application toolbar position - on top. Toolbar on top doesn't interefer with messaging area - and new notifications don't cover buttons.

This change adds a new option - put toolbar on top
