### PR TITLE
Messaging menu integration + background process

### DIFF
--- a/Ubuntu/lightread/LightreadIndicator.py
+++ b/Ubuntu/lightread/LightreadIndicator.py
@@ -30,7 +30,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 ### END LICENSE
-from gi.repository import Indicate # pylint: disable=E0611
+from gi.repository import Indicate
 
 class LightreadIndicator:
     def __init__(self, main_app_window):
@@ -60,4 +60,9 @@ class LightreadIndicator:
         self.ind.show()
 
     def display_main_app(self, indicator, signal):
-        self.main_app.show()
+        is_visible = self.main_app.get_property("visible")
+        if is_visible:
+            self.main_app.present()
+        else:
+            self.main_app.show()
+            

--- a/Ubuntu/lightread/LightreadIndicator.py
+++ b/Ubuntu/lightread/LightreadIndicator.py
@@ -1,0 +1,63 @@
+# -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
+### BEGIN LICENSE
+# Copyright (C) 2012 Caffeinated Code <caffeinatedco.de>
+# Copyright (C) 2012 George Czabania
+# Copyright (C) 2012 Jono Cooper
+# Copyright (c) The Regents of the University of California.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the University nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+# OR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+### END LICENSE
+from gi.repository import Indicate # pylint: disable=E0611
+
+class LightreadIndicator:
+    def __init__(self, main_app_window):
+        self.main_app = main_app_window
+
+        self.server = Indicate.Server.ref_default()         
+        self.server.set_type("message.mail")
+
+        # Apparently if we don't provide a [valid] desktop file
+        # the messaging menu displays our indicator as the top-level entry
+        # which is exactly what I want to do here... 
+        # self.server.set_desktop_file("lightread.desktop")
+        
+        self.ind = Indicate.Indicator()
+        self.ind.set_property("subtype", "mail")
+        self.ind.set_property("name", "Lightread")
+        self.ind.connect("user-display", self.display_main_app)
+        
+        self.server.add_indicator(self.ind)
+        
+        self.server.show()
+
+    def set_unread_count(self, unread_count):
+        self.ind.set_property("count", str(unread_count))
+        self.ind.set_property("draw-attention", 'true')
+
+        self.ind.show()
+
+    def display_main_app(self, indicator, signal):
+        self.main_app.show()

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -47,6 +47,7 @@ logger = logging.getLogger('lightread')
 from lightread_lib import Window
 from lightread_lib.helpers import get_media_file
 from lightread.AboutLightreadDialog import AboutLightreadDialog
+from lightread.LightreadIndicator import LightreadIndicator
 
 # Check for sharingsupport - make sure that gwibber-poster is in PATH
 sharingsupport = os.path.isfile("/usr/bin/gwibber-poster")
@@ -58,6 +59,8 @@ class LightreadWindow(Window):
     def finish_initializing(self, builder): # pylint: disable=E1002
         """Set up the main window"""
         super(LightreadWindow, self).finish_initializing(builder)
+
+        self.indicator = LightreadIndicator(self)
 
         self.AboutDialog = AboutLightreadDialog
         self.scroller = self.builder.get_object("scroller")
@@ -138,6 +141,7 @@ class LightreadWindow(Window):
                             self.set_title(title[1] + " - Lightread")
 
                         launcher.set_property("count", int(title[1]))
+                        self.indicator.set_unread_count(int(title[1]))
                     except UnboundLocalError:
                         pass
 

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -60,7 +60,12 @@ class LightreadWindow(Window):
         """Set up the main window"""
         super(LightreadWindow, self).finish_initializing(builder)
 
+        # Initialize the messaging indicator and pass it this main window
         self.indicator = LightreadIndicator(self)
+
+        # Connect to the delete-event signal triggered when the window's close button is pressed.
+        # Override the default delete event to allow lightread to continue functioning the background.
+        self.connect('delete-event', self._on_delete_event)
 
         self.AboutDialog = AboutLightreadDialog
         self.scroller = self.builder.get_object("scroller")
@@ -180,3 +185,10 @@ class LightreadWindow(Window):
             updatenews.connect ("item-activated", reload_feeds, None)
         except UnboundLocalError:
             pass
+
+    def _on_delete_event(self, widget, event):
+    """ Use PyGTK's hide_on_delete [http://www.pygtk.org/docs/pygtk/class-gtkwidget.html#method-gtkwidget--hide-on-delete]
+    to stop the window's close button from actually closing, and simply hiding instead.
+    This allows us to keep lightread running in the background. Clicking on the lightread indicator will call window.show()
+    and display the main lightread window. """
+        return self.hide_on_delete()


### PR DESCRIPTION
[Bug #1022536](https://bugs.launchpad.net/lightread/+bug/1022536)

Basic integration with the messaging menu to display a single item: Lightread + unread count.
Closing the main lightread menu will no longer close Lightread itself - it will continue to run in the background and can be opened by clicking the lightread entry in the messaging menu.
Closing from File -> Close [ctrl+w] will exit the application and remove the indicator from the messaging menu.
