### PR TITLE
Limit lightread to only opening a single instance

### DIFF
--- a/Ubuntu/lightread/__init__.py
+++ b/Ubuntu/lightread/__init__.py
@@ -33,6 +33,10 @@
 
 import optparse
 
+import dbus.service
+from dbus.mainloop.glib import DBusGMainLoop
+DBusGMainLoop(set_as_default=True)
+
 import gettext
 from gettext import gettext as _
 gettext.textdomain('lightread')
@@ -42,6 +46,21 @@ from gi.repository import Gtk # pylint: disable=E0611
 from lightread import LightreadWindow
 
 from lightread_lib import set_up_logging, get_version
+
+class LightreadDBusService(dbus.service.Object):
+    """ Registers a service on the dbus and listens for proxied requests.
+        When lightread attempts to startup multiple instances, simply proxy a request
+        to the service's bring_to_front method instead.
+    """
+    def __init__(self, lightread_window):
+        bus_name = dbus.service.BusName('org.stayradiated.lightread', bus=dbus.SessionBus())
+        dbus.service.Object.__init__(self, bus_name, '/org/stayradiated/lightread')
+        self.lightread_window = lightread_window
+
+    @dbus.service.method(dbus_interface='org.stayradiated.lightread')
+    def bring_to_front(self):
+        """Pushes the LightreadWindow to the front to be visible"""
+        self.lightread_window.present()
 
 def parse_options():
     """Support for command line options"""
@@ -54,10 +73,25 @@ def parse_options():
     set_up_logging(options)
 
 def main():
-    'constructor for your class instances'
-    parse_options()
+    # We're going to force having only a single instance of lightread up at a time:
+    # First check the dbus to see if an instance of lightread has already been started
+    if dbus.SessionBus().request_name('org.stayradiated.lightread') != dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
+        # If we have an existing instance: find its entry in the dbus
+        bus = dbus.SessionBus()
+        existing_instance = bus.get_object('org.stayradiated.lightread', '/org/stayradiated/lightread')
+        bring_to_front = existing_instance.get_dbus_method('bring_to_front', 'org.stayradiated.lightread')
+        # Make a proxy call to the bring_to_front() method on the existing instance
+        bring_to_front()
+    else:
+        # No pre-existing instance, startup regularly.
+        parse_options()
 
-    # Run the application.    
-    window = LightreadWindow.LightreadWindow()
-    window.show()
-    Gtk.main()
+        # Run the application.
+        window = LightreadWindow.LightreadWindow()
+
+        # Initialize our dbus service and pass it the window instance.
+        lightreadDBusService = LightreadDBusService(window)
+        
+        window.show()
+        Gtk.main()
+        

--- a/Ubuntu/lightread/__init__.py
+++ b/Ubuntu/lightread/__init__.py
@@ -33,34 +33,43 @@
 
 import optparse
 
-import dbus.service
-from dbus.mainloop.glib import DBusGMainLoop
-DBusGMainLoop(set_as_default=True)
-
 import gettext
 from gettext import gettext as _
 gettext.textdomain('lightread')
 
-from gi.repository import Gtk # pylint: disable=E0611
+from gi.repository import Gtk, Gio # pylint: disable=E0611
 
 from lightread import LightreadWindow
 
 from lightread_lib import set_up_logging, get_version
 
-class LightreadDBusService(dbus.service.Object):
-    """ Registers a service on the dbus and listens for proxied requests.
-        When lightread attempts to startup multiple instances, simply proxy a request
-        to the service's bring_to_front method instead.
-    """
-    def __init__(self, lightread_window):
-        bus_name = dbus.service.BusName('org.stayradiated.lightread', bus=dbus.SessionBus())
-        dbus.service.Object.__init__(self, bus_name, '/org/stayradiated/lightread')
-        self.lightread_window = lightread_window
+class LightreadApp(Gtk.Application):
+    """ Wrap lightread in a Gtk.Application instance which by default allows only single instances of applications."""
+    def __init__(self):
+        Gtk.Application.__init__(self, application_id="org.stayradiated.lightread", flags=Gio.ApplicationFlags.FLAGS_NONE)
+        self.connect("activate", self.on_activate)
 
-    @dbus.service.method(dbus_interface='org.stayradiated.lightread')
-    def bring_to_front(self):
-        """Pushes the LightreadWindow to the front to be visible"""
-        self.lightread_window.present()
+    def on_activate(self, data=None):
+        """
+        Check if the application has been activated previously by looking for the LightreadWindow
+        attached to the application. If one is found just bring it to the front with present().
+        If no windows are attached then this must be the first lightread activation... so start it up.
+        """
+        # Try and get any windows belonging to this application.
+        existing_windows = self.get_windows()
+
+        if (len(existing_windows) > 0):
+            # Lightread instance already exists so just bring it to the front.
+            existing_windows[0].present()
+        else:
+            # No pre-existing instance, startup regularly.
+            parse_options()
+            # Startup the main lightread window.
+            window = LightreadWindow.LightreadWindow()
+            # Connect the window to our application so other instances can find it and bring it to the front.
+            window.set_application(self)
+            window.show()
+            Gtk.main()
 
 def parse_options():
     """Support for command line options"""
@@ -73,25 +82,5 @@ def parse_options():
     set_up_logging(options)
 
 def main():
-    # We're going to force having only a single instance of lightread up at a time:
-    # First check the dbus to see if an instance of lightread has already been started
-    if dbus.SessionBus().request_name('org.stayradiated.lightread') != dbus.bus.REQUEST_NAME_REPLY_PRIMARY_OWNER:
-        # If we have an existing instance: find its entry in the dbus
-        bus = dbus.SessionBus()
-        existing_instance = bus.get_object('org.stayradiated.lightread', '/org/stayradiated/lightread')
-        bring_to_front = existing_instance.get_dbus_method('bring_to_front', 'org.stayradiated.lightread')
-        # Make a proxy call to the bring_to_front() method on the existing instance
-        bring_to_front()
-    else:
-        # No pre-existing instance, startup regularly.
-        parse_options()
-
-        # Run the application.
-        window = LightreadWindow.LightreadWindow()
-
-        # Initialize our dbus service and pass it the window instance.
-        lightreadDBusService = LightreadDBusService(window)
-        
-        window.show()
-        Gtk.main()
-        
+    app = LightreadApp()
+    app.run(None)


### PR DESCRIPTION
Prevents lightread from opening multiple instances when the launcher icon is clicked while the previous instance is running in the background.

Registers as a service on the dbus - checks for that registered service on init.
If a previous instance exists show that window rather than instantiating a new instance.

Related to: https://github.com/stayradiated/LightRead/pull/15#issuecomment-8606594
