### PR TITLE
Cleanup python code

### DIFF
--- a/Ubuntu/lightread/AboutLightreadDialog.py
+++ b/Ubuntu/lightread/AboutLightreadDialog.py
@@ -50,4 +50,3 @@ class AboutLightreadDialog(AboutDialog):
         super(AboutLightreadDialog, self).finish_initializing(builder)
 
         # Code for other initialization actions should be added here.
-

--- a/Ubuntu/lightread/AboutLightreadDialog.py
+++ b/Ubuntu/lightread/AboutLightreadDialog.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -43,7 +43,7 @@ from lightread_lib.AboutDialog import AboutDialog
 # See lightread_lib.AboutDialog.py for more details about how this class works.
 class AboutLightreadDialog(AboutDialog):
     __gtype_name__ = "AboutLightreadDialog"
-    
+
     def finish_initializing(self, builder): # pylint: disable=E1002
         """Set up the about dialog"""
         super(AboutLightreadDialog, self).finish_initializing(builder)

--- a/Ubuntu/lightread/AboutLightreadDialog.py
+++ b/Ubuntu/lightread/AboutLightreadDialog.py
@@ -40,6 +40,7 @@ logger = logging.getLogger('lightread')
 
 from lightread_lib.AboutDialog import AboutDialog
 
+
 # See lightread_lib.AboutDialog.py for more details about how this class works.
 class AboutLightreadDialog(AboutDialog):
     __gtype_name__ = "AboutLightreadDialog"

--- a/Ubuntu/lightread/AboutLightreadDialog.py
+++ b/Ubuntu/lightread/AboutLightreadDialog.py
@@ -45,7 +45,7 @@ from lightread_lib.AboutDialog import AboutDialog
 class AboutLightreadDialog(AboutDialog):
     __gtype_name__ = "AboutLightreadDialog"
 
-    def finish_initializing(self, builder): # pylint: disable=E1002
+    def finish_initializing(self, builder):  # pylint: disable=E1002
         """Set up the about dialog"""
         super(AboutLightreadDialog, self).finish_initializing(builder)
 

--- a/Ubuntu/lightread/LightreadIndicator.py
+++ b/Ubuntu/lightread/LightreadIndicator.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -37,21 +37,21 @@ class LightreadIndicator:
         self.main_app = main_app_window
         self.is_visible = False
 
-        self.server = Indicate.Server.ref_default()         
+        self.server = Indicate.Server.ref_default()
         self.server.set_type("message.mail")
 
         # Apparently if we don't provide a [valid] desktop file
         # the messaging menu displays our indicator as the top-level entry
-        # which is exactly what I want to do here... 
+        # which is exactly what I want to do here...
         # self.server.set_desktop_file("lightread.desktop")
-        
+
         self.ind = Indicate.Indicator()
         self.ind.set_property("subtype", "mail")
         self.ind.set_property("name", "Lightread")
         self.ind.connect("user-display", self.display_main_app)
-        
+
         self.server.add_indicator(self.ind)
-        
+
     def set_unread_count(self, unread_count):
         self.ind.set_property("count", str(unread_count))
 

--- a/Ubuntu/lightread/LightreadIndicator.py
+++ b/Ubuntu/lightread/LightreadIndicator.py
@@ -32,6 +32,7 @@
 ### END LICENSE
 from gi.repository import Indicate
 
+
 class LightreadIndicator:
     def __init__(self, main_app_window):
         self.main_app = main_app_window

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -57,6 +57,7 @@ import json
 # Check for sharingsupport - make sure that gwibber-poster is in PATH
 sharingsupport = os.path.isfile("/usr/bin/gwibber-poster")
 
+
 # See lightread_lib.Window.py for more details about how this class works
 class LightreadWindow(Window):
     __gtype_name__ = "LightreadWindow"

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -209,8 +209,8 @@ class LightreadWindow(Window):
             pass
 
     def _on_delete_event(self, widget, event):
-    	""" Use PyGTK's hide_on_delete [http://www.pygtk.org/docs/pygtk/class-gtkwidget.html#method-gtkwidget--hide-on-delete]
-    	to stop the window's close button from actually closing, and simply hiding instead.
-    	This allows us to keep lightread running in the background. Clicking on the lightread indicator will call window.show()
-    	and display the main lightread window. """
+        """ Use PyGTK's hide_on_delete [http://www.pygtk.org/docs/pygtk/class-gtkwidget.html#method-gtkwidget--hide-on-delete]
+        to stop the window's close button from actually closing, and simply hiding instead.
+        This allows us to keep lightread running in the background. Clicking on the lightread indicator will call window.show()
+        and display the main lightread window. """
         return self.hide_on_delete()

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -101,13 +101,13 @@ class LightreadWindow(Window):
         self.notification = Notify.Notification.new('Lightread', '', 'lightread')
 
         try:
-            launcher = Unity.LauncherEntry.get_for_desktop_id ("extras-lightread.desktop")
+            launcher = Unity.LauncherEntry.get_for_desktop_id("extras-lightread.desktop")
 
-            ql = Dbusmenu.Menuitem.new ()
-            updatenews = Dbusmenu.Menuitem.new ()
-            updatenews.property_set (Dbusmenu.MENUITEM_PROP_LABEL, "Update News")
-            updatenews.property_set_bool (Dbusmenu.MENUITEM_PROP_VISIBLE, True)
-            ql.child_append (updatenews)
+            ql = Dbusmenu.Menuitem.new()
+            updatenews = Dbusmenu.Menuitem.new()
+            updatenews.property_set(Dbusmenu.MENUITEM_PROP_LABEL, "Update News")
+            updatenews.property_set_bool(Dbusmenu.MENUITEM_PROP_VISIBLE, True)
+            ql.child_append(updatenews)
             launcher.set_property("quicklist", ql)
         except NameError:
             pass
@@ -196,18 +196,18 @@ class LightreadWindow(Window):
         self.webview.connect('navigation-requested', _navigation_requested_cb)
         self.webview.connect('console-message', console_message_cb)
 
-        self.add.connect ("activate", menuexternal, None)
-        self.refresh.connect ("activate", menuexternal, None)
-        self.star.connect ("activate", menuexternal, None)
-        self.read.connect ("activate", menuexternal, None)
-        self.logout.connect ("activate", menuexternal, None)
-        self.next_article.connect ("activate", menuexternal, None)
-        self.prev_article.connect ("activate", menuexternal, None)
-        self.filter_all.connect ("activate", menuexternal, None)
-        self.filter_unread.connect ("activate", menuexternal, None)
-        self.filter_starred.connect ("activate", menuexternal, None)
+        self.add.connect("activate", menuexternal, None)
+        self.refresh.connect("activate", menuexternal, None)
+        self.star.connect("activate", menuexternal, None)
+        self.read.connect("activate", menuexternal, None)
+        self.logout.connect("activate", menuexternal, None)
+        self.next_article.connect("activate", menuexternal, None)
+        self.prev_article.connect("activate", menuexternal, None)
+        self.filter_all.connect("activate", menuexternal, None)
+        self.filter_unread.connect("activate", menuexternal, None)
+        self.filter_starred.connect("activate", menuexternal, None)
         try:
-            updatenews.connect ("item-activated", reload_feeds, None)
+            updatenews.connect("item-activated", reload_feeds, None)
         except UnboundLocalError:
             pass
 

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -157,7 +157,7 @@ class LightreadWindow(Window):
                 elif title[0] == 'notify':
                     # Update notification and show only if not changed and window not focused
                     if self.notification.get_property('body') != title[2]:
-                        if self.is_active() != True:
+                        if self.is_active() is not True:
                             self.notification.set_property('body', title[2])
                             self.notification.show()
 
@@ -174,18 +174,18 @@ class LightreadWindow(Window):
 
                     settings_json = json.loads(title[1])
 
-                    if settings_json.get('indicators') == True:
+                    if settings_json.get('indicators') is True:
                         if self.indicator is None:
                             self.indicator = LightreadIndicator(self)
                         self.indicator.show()
-                    elif settings_json.get('indicators') == False and self.indicator is not None:
+                    elif settings_json.get('indicators') is False and self.indicator is not None:
                         # indicator set to false but was already created: hide it
                         self.indicator.hide()
 
                     # if settings background true and not self.is connected delete-event
-                    if settings_json.get('background') == True and self.window_close_handler is None:
+                    if settings_json.get('background') is True and self.window_close_handler is None:
                         self.window_close_handler = self.connect('delete-event', self._on_delete_event)
-                    elif settings_json.get('background') == False and self.window_close_handler is not None:
+                    elif settings_json.get('background') is False and self.window_close_handler is not None:
                         self.disconnect(self.window_close_handler)
                         self.window_close_handler = None
 

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -113,10 +113,10 @@ class LightreadWindow(Window):
             pass
 
         # Message Passing Stuff
-        def reload_feeds(this, widget, data = None):
+        def reload_feeds(this, widget, data=None):
             self.webview.execute_script('cmd("refresh")')
 
-        def menuexternal(this, widget, data = None):
+        def menuexternal(this, widget, data=None):
             print(this)
             print(this.get_name())
             self.webview.execute_script('cmd("' + this.get_name() + '")')

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -36,7 +36,7 @@ from gettext import gettext as _
 gettext.textdomain('lightread')
 
 import subprocess, os
-from gi.repository import Gtk, Gdk, WebKit, Notify # pylint: disable=E0611
+from gi.repository import Gtk, Gdk, WebKit, Notify  # pylint: disable=E0611
 try:
     from gi.repository import Unity, Dbusmenu
 except ImportError:
@@ -62,7 +62,7 @@ sharingsupport = os.path.isfile("/usr/bin/gwibber-poster")
 class LightreadWindow(Window):
     __gtype_name__ = "LightreadWindow"
 
-    def finish_initializing(self, builder): # pylint: disable=E1002
+    def finish_initializing(self, builder):  # pylint: disable=E1002
         """Set up the main window"""
         super(LightreadWindow, self).finish_initializing(builder)
 

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -95,7 +95,6 @@ class LightreadWindow(Window):
         self.filter_unread = self.builder.get_object("filter-unread")
         self.filter_starred = self.builder.get_object("filter-starred")
 
-
         # Unity Support
         Notify.init('Lightread')
         self.notification = Notify.Notification.new('Lightread', '', 'lightread')
@@ -154,7 +153,6 @@ class LightreadWindow(Window):
                     except UnboundLocalError:
                         pass
 
-
                 elif title[0] == 'notify':
                     # Update notification and show only if not changed and window not focused
                     if self.notification.get_property('body') != title[2]:
@@ -189,7 +187,6 @@ class LightreadWindow(Window):
                     elif settings_json.get('background') is False and self.window_close_handler is not None:
                         self.disconnect(self.window_close_handler)
                         self.window_close_handler = None
-
 
         # Connects to WebView
         self.webview.connect('title-changed', title_changed)

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -35,7 +35,8 @@ import gettext
 from gettext import gettext as _
 gettext.textdomain('lightread')
 
-import subprocess, os
+import subprocess
+import os
 from gi.repository import Gtk, Gdk, WebKit, Notify  # pylint: disable=E0611
 try:
     from gi.repository import Unity, Dbusmenu

--- a/Ubuntu/lightread/__init__.py
+++ b/Ubuntu/lightread/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/Ubuntu/lightread/__init__.py
+++ b/Ubuntu/lightread/__init__.py
@@ -37,7 +37,7 @@ import gettext
 from gettext import gettext as _
 gettext.textdomain('lightread')
 
-from gi.repository import Gtk, Gio # pylint: disable=E0611
+from gi.repository import Gtk, Gio  # pylint: disable=E0611
 
 from lightread import LightreadWindow
 

--- a/Ubuntu/lightread/__init__.py
+++ b/Ubuntu/lightread/__init__.py
@@ -43,6 +43,7 @@ from lightread import LightreadWindow
 
 from lightread_lib import set_up_logging, get_version
 
+
 class LightreadApp(Gtk.Application):
     """ Wrap lightread in a Gtk.Application instance which by default allows only single instances of applications."""
     def __init__(self):
@@ -71,6 +72,7 @@ class LightreadApp(Gtk.Application):
             window.show()
             Gtk.main()
 
+
 def parse_options():
     """Support for command line options"""
     parser = optparse.OptionParser(version="%%prog %s" % get_version())
@@ -80,6 +82,7 @@ def parse_options():
     (options, args) = parser.parse_args()
 
     set_up_logging(options)
+
 
 def main():
     app = LightreadApp()

--- a/Ubuntu/lightread_lib/AboutDialog.py
+++ b/Ubuntu/lightread_lib/AboutDialog.py
@@ -63,4 +63,3 @@ class AboutDialog(Gtk.AboutDialog):
         # Get a reference to the builder and set up the signals.
         self.builder = builder
         self.ui = builder.get_ui(self)
-

--- a/Ubuntu/lightread_lib/AboutDialog.py
+++ b/Ubuntu/lightread_lib/AboutDialog.py
@@ -31,7 +31,7 @@
 # SUCH DAMAGE.
 ### END LICENSE
 
-from gi.repository import Gtk # pylint: disable=E0611
+from gi.repository import Gtk  # pylint: disable=E0611
 
 from . helpers import get_builder
 

--- a/Ubuntu/lightread_lib/AboutDialog.py
+++ b/Ubuntu/lightread_lib/AboutDialog.py
@@ -35,6 +35,7 @@ from gi.repository import Gtk # pylint: disable=E0611
 
 from . helpers import get_builder
 
+
 class AboutDialog(Gtk.AboutDialog):
     __gtype_name__ = "AboutDialog"
 

--- a/Ubuntu/lightread_lib/AboutDialog.py
+++ b/Ubuntu/lightread_lib/AboutDialog.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -39,9 +39,9 @@ class AboutDialog(Gtk.AboutDialog):
     __gtype_name__ = "AboutDialog"
 
     def __new__(cls):
-        """Special static method that's automatically called by Python when 
+        """Special static method that's automatically called by Python when
         constructing a new instance of this class.
-        
+
         Returns a fully instantiated AboutDialog object.
         """
         builder = get_builder('AboutLightreadDialog')
@@ -56,7 +56,7 @@ class AboutDialog(Gtk.AboutDialog):
         and creating a AboutDialog object with it in order
         to finish initializing the start of the new AboutLightreadDialog
         instance.
-        
+
         Put your initialization code in here and leave __init__ undefined.
         """
         # Get a reference to the builder and set up the signals.

--- a/Ubuntu/lightread_lib/Builder.py
+++ b/Ubuntu/lightread_lib/Builder.py
@@ -69,15 +69,15 @@ class Builder(Gtk.Builder):
 
 # pylint: disable=R0201
 # this is a method so that a subclass of Builder can redefine it
-    def default_handler(self,
-        handler_name, filename, *args, **kwargs):
+    def default_handler(self, handler_name, filename, *args, **kwargs):
         '''helps the apprentice guru
 
-    glade defined handlers that do not exist come here instead.
-    An apprentice guru might wonder which signal does what he wants,
-    now he can define any likely candidates in glade and notice which
-    ones get triggered when he plays with the project.
-    this method does not appear in Gtk.Builder'''
+        glade defined handlers that do not exist come here instead.
+        An apprentice guru might wonder which signal does what he wants,
+        now he can define any likely candidates in glade and notice which
+        ones get triggered when he plays with the project.
+        this method does not appear in Gtk.Builder'''
+
         logger.debug('''tried to call non-existent function:%s()
         expected in %s
         args:%s
@@ -114,8 +114,8 @@ class Builder(Gtk.Builder):
 
             connections = [
                 (name,
-                ele_signal.attrib['name'],
-                ele_signal.attrib['handler']) for ele_signal in ele_signals]
+                    ele_signal.attrib['name'],
+                    ele_signal.attrib['handler']) for ele_signal in ele_signals]
 
             if connections:
                 self.connections.extend(connections)
@@ -123,7 +123,7 @@ class Builder(Gtk.Builder):
         ele_signals = tree.getiterator("signal")
         for ele_signal in ele_signals:
             self.glade_handler_dict.update(
-            {ele_signal.attrib["handler"]: None})
+                {ele_signal.attrib["handler"]: None})
 
     def connect_signals(self, callback_obj):
         '''connect the handlers defined in glade
@@ -145,7 +145,7 @@ class Builder(Gtk.Builder):
 
                 # replace the run time warning
                 logger.warn("expected handler '%s' in %s",
-                 item[0], filename)
+                            item[0], filename)
 
         # connect glade define handlers
         Gtk.Builder.connect_signals(self, connection_dict)
@@ -154,7 +154,7 @@ class Builder(Gtk.Builder):
         for connection in self.connections:
             widget_name, signal_name, handler_name = connection
             logger.debug("connect builder by design '%s', '%s', '%s'",
-             widget_name, signal_name, handler_name)
+                         widget_name, signal_name, handler_name)
 
     def get_ui(self, callback_obj=None, by_name=True):
         '''Creates the ui object with widgets as attributes
@@ -216,7 +216,7 @@ def make_pyname(name):
     pyname = ''
     for character in name:
         if (character.isalpha() or character == '_' or
-            (pyname and character.isdigit())):
+                (pyname and character.isdigit())):
             pyname += character
         else:
             pyname += '_'
@@ -300,13 +300,13 @@ def auto_connect_by_name(callback_obj, builder):
                 handler_names.append("on_%s" % sig)
 
             do_connect(item, sig, handler_names,
-             callback_handler_dict, builder.connections)
+                       callback_handler_dict, builder.connections)
 
     log_unconnected_functions(callback_handler_dict, builder.connections)
 
 
 def do_connect(item, signal_name, handler_names,
-        callback_handler_dict, connections):
+               callback_handler_dict, connections):
     '''connect this signal to an unused handler'''
     widget_name, widget = item
 
@@ -319,7 +319,7 @@ def do_connect(item, signal_name, handler_names,
             connections.append(connection)
 
             logger.debug("connect builder by name '%s','%s', '%s'",
-             widget_name, signal_name, handler_name)
+                         widget_name, signal_name, handler_name)
 
 
 def log_unconnected_functions(callback_handler_dict, connections):

--- a/Ubuntu/lightread_lib/Builder.py
+++ b/Ubuntu/lightread_lib/Builder.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -190,7 +190,7 @@ class UiFactory():
         cannot_message = """cannot bind ui.%s, name already exists
         consider using a pythonic name instead of design name '%s'"""
         consider_message = """consider using a pythonic name instead of design name '%s'"""
-        
+
         for (widget_name, widget) in widget_dict.items():
             pyname = make_pyname(widget_name)
             if pyname != widget_name:
@@ -223,7 +223,7 @@ def make_pyname(name):
     return pyname
 
 
-# Until bug https://bugzilla.gnome.org/show_bug.cgi?id=652127 is fixed, we 
+# Until bug https://bugzilla.gnome.org/show_bug.cgi?id=652127 is fixed, we
 # need to reimplement inspect.getmembers.  GObject introspection doesn't
 # play nice with it.
 def getmembers(obj, check):

--- a/Ubuntu/lightread_lib/Builder.py
+++ b/Ubuntu/lightread_lib/Builder.py
@@ -33,7 +33,7 @@
 
 '''Enhances builder connections, provides object to access glade objects'''
 
-from gi.repository import GObject, Gtk # pylint: disable=E0611
+from gi.repository import GObject, Gtk  # pylint: disable=E0611
 
 import inspect
 import functools

--- a/Ubuntu/lightread_lib/Window.py
+++ b/Ubuntu/lightread_lib/Window.py
@@ -31,7 +31,7 @@
 # SUCH DAMAGE.
 ### END LICENSE
 
-from gi.repository import Gio, Gtk # pylint: disable=E0611
+from gi.repository import Gio, Gtk  # pylint: disable=E0611
 import logging
 logger = logging.getLogger('lightread_lib')
 
@@ -74,7 +74,7 @@ class Window(Gtk.Window):
         # Get a reference to the builder and set up the signals.
         self.builder = builder
         self.ui = builder.get_ui(self, True)
-        self.AboutDialog = None # class
+        self.AboutDialog = None  # class
 
         self.settings = Gio.Settings("net.launchpad.lightread")
 
@@ -83,7 +83,7 @@ class Window(Gtk.Window):
         # See https://wiki.ubuntu.com/UbuntuDevelopment/Internationalisation/Coding
         # for more information about Launchpad integration.
         try:
-            from gi.repository import LaunchpadIntegration # pylint: disable=E0611
+            from gi.repository import LaunchpadIntegration  # pylint: disable=E0611
             LaunchpadIntegration.add_items(self.ui.helpMenu, 1, True, True)
             LaunchpadIntegration.set_sourcepackagename('lightread')
         except ImportError:
@@ -108,7 +108,7 @@ class Window(Gtk.Window):
     def on_mnu_about_activate(self, widget, data=None):
         """Display the about box for lightread."""
         if self.AboutDialog is not None:
-            about = self.AboutDialog() # pylint: disable=E1102
+            about = self.AboutDialog()  # pylint: disable=E1102
             response = about.run()
             about.destroy()
 

--- a/Ubuntu/lightread_lib/Window.py
+++ b/Ubuntu/lightread_lib/Window.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -42,7 +42,7 @@ from . helpers import get_builder, show_uri, get_help_uri
 class Window(Gtk.Window):
     __gtype_name__ = "Window"
 
-    # To construct a new instance of this method, the following notable 
+    # To construct a new instance of this method, the following notable
     # methods are called in this order:
     # __new__(cls)
     # __init__(self)
@@ -51,11 +51,11 @@ class Window(Gtk.Window):
     #
     # For this reason, it's recommended you leave __init__ empty and put
     # your initialization code in finish_initializing
-    
+
     def __new__(cls):
-        """Special static method that's automatically called by Python when 
+        """Special static method that's automatically called by Python when
         constructing a new instance of this class.
-        
+
         Returns a fully instantiated BaseLightreadWindow object.
         """
         builder = get_builder('LightreadWindow')

--- a/Ubuntu/lightread_lib/Window.py
+++ b/Ubuntu/lightread_lib/Window.py
@@ -37,6 +37,7 @@ logger = logging.getLogger('lightread_lib')
 
 from . helpers import get_builder, show_uri, get_help_uri
 
+
 # This class is meant to be subclassed by LightreadWindow.  It provides
 # common functions and some boilerplate.
 class Window(Gtk.Window):

--- a/Ubuntu/lightread_lib/Window.py
+++ b/Ubuntu/lightread_lib/Window.py
@@ -120,4 +120,3 @@ class Window(Gtk.Window):
         """Called when the LightreadWindow is closed."""
         # Clean up code for saving application state should be added here.
         Gtk.main_quit()
-

--- a/Ubuntu/lightread_lib/__init__.py
+++ b/Ubuntu/lightread_lib/__init__.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/Ubuntu/lightread_lib/__init__.py
+++ b/Ubuntu/lightread_lib/__init__.py
@@ -37,4 +37,3 @@ while keeping its api constant'''
 from . helpers import set_up_logging
 from . Window import Window
 from . lightreadconfig import get_version
-

--- a/Ubuntu/lightread_lib/helpers.py
+++ b/Ubuntu/lightread_lib/helpers.py
@@ -118,7 +118,7 @@ def get_help_uri(page=None):
 
 
 def show_uri(parent, link):
-    from gi.repository import Gtk # pylint: disable=E0611
+    from gi.repository import Gtk  # pylint: disable=E0611
     screen = parent.get_screen()
     Gtk.show_uri(screen, link, Gtk.get_current_event_time())
 

--- a/Ubuntu/lightread_lib/helpers.py
+++ b/Ubuntu/lightread_lib/helpers.py
@@ -67,7 +67,7 @@ def get_media_file(media_file_name):
     if not os.path.exists(media_filename):
         media_filename = None
 
-    return "file:///"+media_filename
+    return "file:///" + media_filename
 
 
 class NullHandler(logging.Handler):

--- a/Ubuntu/lightread_lib/helpers.py
+++ b/Ubuntu/lightread_lib/helpers.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -43,9 +43,9 @@ from gettext import gettext as _
 gettext.textdomain('lightread')
 
 def get_builder(builder_file_name):
-    """Return a fully-instantiated Gtk.Builder instance from specified ui 
+    """Return a fully-instantiated Gtk.Builder instance from specified ui
     file
-    
+
     :param builder_file_name: The name of the builder file, without extension.
         Assumed to be in the 'ui' directory under the data path.
     """

--- a/Ubuntu/lightread_lib/helpers.py
+++ b/Ubuntu/lightread_lib/helpers.py
@@ -42,6 +42,7 @@ import gettext
 from gettext import gettext as _
 gettext.textdomain('lightread')
 
+
 def get_builder(builder_file_name):
     """Return a fully-instantiated Gtk.Builder instance from specified ui
     file
@@ -68,9 +69,11 @@ def get_media_file(media_file_name):
 
     return "file:///"+media_filename
 
+
 class NullHandler(logging.Handler):
     def emit(self, record):
         pass
+
 
 def set_up_logging(opts):
     # add a handler to prevent basicConfig
@@ -97,6 +100,7 @@ def set_up_logging(opts):
         if opts.verbose > 1:
             lib_logger.setLevel(logging.DEBUG)
 
+
 def get_help_uri(page=None):
     # help_uri from source tree - default language
     here = os.path.dirname(__file__)
@@ -112,10 +116,12 @@ def get_help_uri(page=None):
 
     return help_uri
 
+
 def show_uri(parent, link):
     from gi.repository import Gtk # pylint: disable=E0611
     screen = parent.get_screen()
     Gtk.show_uri(screen, link, Gtk.get_current_event_time())
+
 
 def alias(alternative_function_name):
     '''see http://www.drdobbs.com/web-development/184406073#l9'''

--- a/Ubuntu/lightread_lib/lightreadconfig.py
+++ b/Ubuntu/lightread_lib/lightreadconfig.py
@@ -40,7 +40,7 @@ __all__ = [
     'project_path_not_found',
     'get_data_file',
     'get_data_path',
-    ]
+]
 
 # Where your project will look for your data (for instance, images and ui
 # files). By default, this is ../data, relative your trunk layout

--- a/Ubuntu/lightread_lib/lightreadconfig.py
+++ b/Ubuntu/lightread_lib/lightreadconfig.py
@@ -54,6 +54,7 @@ import gettext
 from gettext import gettext as _
 gettext.textdomain('lightread')
 
+
 class project_path_not_found(Exception):
     """Raised when we can't find the project directory."""
 

--- a/Ubuntu/lightread_lib/lightreadconfig.py
+++ b/Ubuntu/lightread_lib/lightreadconfig.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -17,7 +17,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/Ubuntu/setup.py
+++ b/Ubuntu/setup.py
@@ -63,7 +63,7 @@ def update_config(values={}):
         fin.close()
         os.rename(fout.name, fin.name)
     except (OSError, IOError), e:
-        print ("ERROR: Can't find lightread_lib/lightreadconfig.py")
+        print("ERROR: Can't find lightread_lib/lightreadconfig.py")
         sys.exit(1)
     return oldvalues
 

--- a/Ubuntu/setup.py
+++ b/Ubuntu/setup.py
@@ -44,8 +44,8 @@ except ImportError:
     sys.exit(1)
 assert DistUtilsExtra.auto.__version__ >= '2.18', 'needs DistUtilsExtra.auto >= 2.18'
 
-def update_config(values = {}):
 
+def update_config(values = {}):
     oldvalues = {}
     try:
         fin = file('lightread_lib/lightreadconfig.py', 'r')

--- a/Ubuntu/setup.py
+++ b/Ubuntu/setup.py
@@ -77,11 +77,9 @@ class InstallAndUpdateDataDirectory(DistUtilsExtra.auto.install_auto):
         update_config(previous_values)
 
 
-
 ##################################################################################
 ###################### YOU SHOULD MODIFY ONLY WHAT IS BELOW ######################
 ##################################################################################
-
 DistUtilsExtra.auto.setup(
     name='lightread',
     version='1.0.20',

--- a/Ubuntu/setup.py
+++ b/Ubuntu/setup.py
@@ -94,4 +94,3 @@ DistUtilsExtra.auto.setup(
     cmdclass={'install': InstallAndUpdateDataDirectory},
     data_files=[('share/icons/hicolor/128x128/apps', ['data/media/lightread.png'])]
 )
-

--- a/Ubuntu/setup.py
+++ b/Ubuntu/setup.py
@@ -93,5 +93,5 @@ DistUtilsExtra.auto.setup(
     url='https://launchpad.net/lightread',
     cmdclass={'install': InstallAndUpdateDataDirectory},
     data_files=[('share/icons/hicolor/128x128/apps', ['data/media/lightread.png'])]
-    )
+)
 

--- a/Ubuntu/setup.py
+++ b/Ubuntu/setup.py
@@ -45,7 +45,7 @@ except ImportError:
 assert DistUtilsExtra.auto.__version__ >= '2.18', 'needs DistUtilsExtra.auto >= 2.18'
 
 
-def update_config(values = {}):
+def update_config(values={}):
     oldvalues = {}
     try:
         fin = file('lightread_lib/lightreadconfig.py', 'r')

--- a/Ubuntu/setup.py
+++ b/Ubuntu/setup.py
@@ -52,7 +52,7 @@ def update_config(values={}):
         fout = file(fin.name + '.new', 'w')
 
         for line in fin:
-            fields = line.split(' = ') # Separate variable from value
+            fields = line.split(' = ')  # Separate variable from value
             if fields[0] in values:
                 oldvalues[fields[0]] = fields[1].strip()
                 line = "%s = %s\n" % (fields[0], values[fields[0]])

--- a/Ubuntu/tests/test_example.py
+++ b/Ubuntu/tests/test_example.py
@@ -43,7 +43,7 @@ from lightread import AboutLightreadDialog
 class TestExample(unittest.TestCase):
     def setUp(self):
         self.AboutLightreadDialog_members = [
-        'AboutDialog', 'AboutLightreadDialog', 'gettext', 'logger', 'logging']
+            'AboutDialog', 'AboutLightreadDialog', 'gettext', 'logger', 'logging']
 
     def test_AboutLightreadDialog_members(self):
         all_members = dir(AboutLightreadDialog)

--- a/Ubuntu/tests/test_example.py
+++ b/Ubuntu/tests/test_example.py
@@ -39,6 +39,7 @@ sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), ".."
 
 from lightread import AboutLightreadDialog
 
+
 class TestExample(unittest.TestCase):
     def setUp(self):
         self.AboutLightreadDialog_members = [

--- a/Ubuntu/tests/test_example.py
+++ b/Ubuntu/tests/test_example.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -18,7 +18,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -50,5 +50,5 @@ class TestExample(unittest.TestCase):
         public_members.sort()
         self.assertEqual(self.AboutLightreadDialog_members, public_members)
 
-if __name__ == '__main__':    
+if __name__ == '__main__':
     unittest.main()

--- a/Ubuntu/tests/test_lint.py
+++ b/Ubuntu/tests/test_lint.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2012 Jono Cooper
 # Copyright (c) The Regents of the University of California.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -18,7 +18,7 @@
 # 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -38,17 +38,17 @@ import subprocess
 class TestPylint(unittest.TestCase):
     def test_project_errors_only(self):
         '''run pylint in error only mode
-        
+
         your code may well work even with pylint errors
         but have some unusual code'''
         return_code = subprocess.call(["pylint", '-E', 'lightread'])
         # not needed because nosetests displays pylint console output
         #self.assertEqual(return_code, 0)
 
-    # un-comment the following for loads of diagnostics   
+    # un-comment the following for loads of diagnostics
     #~ def test_project_full_report(self):
         #~ '''Only for the brave
-#~ 
+#~
         #~ you will have to make judgement calls about your code standards
         #~ that differ from the norm'''
         #~ return_code = subprocess.call(["pylint", 'lightread'])

--- a/Ubuntu/tests/test_lint.py
+++ b/Ubuntu/tests/test_lint.py
@@ -35,6 +35,7 @@
 import unittest
 import subprocess
 
+
 class TestPylint(unittest.TestCase):
     def test_project_errors_only(self):
         '''run pylint in error only mode


### PR DESCRIPTION
Code changes are done in accordance with PEP8 (except for line length).
PEP8 styled code was the dominant code before my changes. 

Changes include:
- "x is True" instead of "x == True"
- Proper identation (makes code more readable)
- Removing of whitespace
- Converting mixed/tab-only indentations to spaces
- Misc. stuff (commit descriptions should be self-explanatory)
