### PR TITLE
Individual indicators for each unread feed in the messaging menu

### DIFF
--- a/App/scripts/app.js
+++ b/App/scripts/app.js
@@ -240,7 +240,7 @@ $(function() {
 		e.stopPropagation()
 	})
 
-	cmd = function(req) {
+	cmd = function(req, args) {
 		switch(req) {
 
 			case "add":
@@ -349,6 +349,12 @@ $(function() {
 			case 'markAllAsRead':
 				if (selected.feed.id) {
 					core.markAllAsRead(selected.feed.id)
+				}
+				break
+
+			case 'select-feed':
+				if (args && args.feedID) {
+					ui.selectFeed(ui.getFeedView(args.feedID));
 				}
 				break
 		}

--- a/App/scripts/app.js
+++ b/App/scripts/app.js
@@ -377,6 +377,9 @@ $(function() {
  			case 'settings':
  				document.title = 'settings|' + value
  				break
+ 			case 'feed_count':
+ 				document.title = 'feed_count|' + value
+ 				break
 		}
 	}
 

--- a/App/scripts/app/ui.js
+++ b/App/scripts/app/ui.js
@@ -392,6 +392,8 @@ ui = {
 			title: feed.title,
 			count: count
 		}
+
+		python('feed_count', JSON.stringify({"id": encodeURIComponent(model.id), "title": encodeURIComponent(model.title), "count": model.count}))
 		return template.feed(model)
 	},
 

--- a/Ubuntu/lightread/LightreadIndicator.py
+++ b/Ubuntu/lightread/LightreadIndicator.py
@@ -83,13 +83,6 @@ class LightreadIndicator:
             # indicator.hide()
             self.server.remove_indicator(indicator)
 
-    def new_mail(self, account, count):
-        indicator = self.indicators[account]
-        self.count += count
-        indicator.set_property('count', str(self.count))
-        indicator.set_property('draw-attention', 'true')
-        indicator.show()
-
     def display_main_app(self, indicator, signal):
         is_visible = self.main_app.get_property("visible")
         if is_visible:

--- a/Ubuntu/lightread/LightreadIndicator.py
+++ b/Ubuntu/lightread/LightreadIndicator.py
@@ -32,33 +32,63 @@
 ### END LICENSE
 from gi.repository import Indicate
 
+# Note: it seems the messaging api has been improved greatly for Quantal [12.10]
+# Unfortunately it isn't backwards compatible. The only decent reference I can find
+# for now is https://wiki.edubuntu.org/MeetingLogs/devweek1208/libmessagingmenu
 
 class LightreadIndicator:
     def __init__(self, main_app_window):
         self.main_app = main_app_window
         self.is_visible = False
+        self.indicators = {}
+        self.desktop_file = "/usr/share/applications/extras-lightread.desktop"
 
+        # Create the base messaging server with the application name and icon
         self.server = Indicate.Server.ref_default()
         self.server.set_type("message.mail")
+        self.server.set_desktop_file(self.desktop_file)
+        self.server.connect("server-display", self.display_main_app)
 
         # Apparently if we don't provide a [valid] desktop file
         # the messaging menu displays our indicator as the top-level entry
         # which is exactly what I want to do here...
         # self.server.set_desktop_file("lightread.desktop")
+        # self.ind = Indicate.Indicator()
+        # self.ind.set_property("subtype", "mail")
+        # self.ind.set_property("name", "Lightread")
+        # self.ind.connect("user-display", self.display_main_app)
 
-        self.ind = Indicate.Indicator()
-        self.ind.set_property("subtype", "mail")
-        self.ind.set_property("name", "Lightread")
-        self.ind.connect("user-display", self.display_main_app)
+        # self.server.add_indicator(self.ind)
 
-        self.server.add_indicator(self.ind)
+    def add_indicator(self, feed_id, feed_title, feed_count):
+        if feed_id in self.indicators.keys():
+            indicator = self.indicators[feed_id]
+        else:
+            indicator = Indicate.Indicator()
+            indicator.set_property("subtype", "mail")
+            indicator.set_property("name", feed_title)
+            indicator.connect("user-display", self.display_feed, feed_id)
+            self.indicators[feed_id] = indicator
+            self.server.add_indicator(indicator)
 
-    def set_unread_count(self, unread_count):
-        self.ind.set_property("count", str(unread_count))
+        indicator.set_property('count', str(feed_count))
+        indicator.set_property('draw-attention', 'true')
+        indicator.show()
 
-        if self.is_visible:
-            self.ind.set_property("draw-attention", 'true')
-            self.ind.show()
+    def remove_indicator(self, feed_id):
+        if feed_id in self.indicators.keys():
+            indicator = self.indicators[feed_id]
+            # indicator.set_property('count', '0')
+            # indicator.set_property('draw-attention', 'false')
+            # indicator.hide()
+            self.server.remove_indicator(indicator)
+
+    def new_mail(self, account, count):
+        indicator = self.indicators[account]
+        self.count += count
+        indicator.set_property('count', str(self.count))
+        indicator.set_property('draw-attention', 'true')
+        indicator.show()
 
     def display_main_app(self, indicator, signal):
         is_visible = self.main_app.get_property("visible")
@@ -67,12 +97,14 @@ class LightreadIndicator:
         else:
             self.main_app.show()
 
+    def display_feed(self, indicator, signal, feed_id):
+        self.display_main_app(indicator, signal)
+        self.main_app.select_feed(feed_id)
+
     def hide(self):
         self.server.hide()
-        self.ind.hide()
         self.is_visible = False
 
     def show(self):
         self.server.show()
-        self.ind.show()
         self.is_visible = True

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -34,6 +34,8 @@
 import logging
 logger = logging.getLogger('lightread')
 
+import urllib
+
 import gettext
 from gettext import gettext as _
 gettext.textdomain('lightread')
@@ -74,6 +76,11 @@ sharingsupport = os.path.isfile("/usr/bin/gwibber-poster")
 # See lightread_lib.Window.py for more details about how this class works
 class LightreadWindow(Window):
     __gtype_name__ = "LightreadWindow"
+
+    def select_feed(self, feed_id):
+        select_args = {'feedID': feed_id}
+        js_comm = 'cmd("%s", %s)' % ('select-feed', json.dumps(select_args))
+        self.webview.execute_script(js_comm)
 
     def inspect_webview(self, inspector, widget, data=None):
         inspector_view = WebKit.WebView()
@@ -193,8 +200,8 @@ class LightreadWindow(Window):
                             self.set_title(title[1] + " - Lightread")
 
                         launcher.set_property("count", int(title[1]))
-                        if self.indicator is not None:
-                            self.indicator.set_unread_count(int(title[1]))
+                        # if self.indicator is not None:
+                        #     self.indicator.set_unread_count(int(title[1]))
                     except UnboundLocalError:
                         pass
 
@@ -232,6 +239,15 @@ class LightreadWindow(Window):
                     elif settings_json.get('background') is False and self.window_close_handler is not None:
                         self.disconnect(self.window_close_handler)
                         self.window_close_handler = None
+
+                elif title[0] == 'feed_count':
+                    if self.indicator is not None:
+                        feed_json = json.loads(title[1])
+                        count = int(feed_json['count'])
+                        if count > 0:
+                            self.indicator.add_indicator(urllib.unquote(feed_json['id']), urllib.unquote(feed_json['title']), count)
+                        else:
+                            self.indicator.remove_indicator(urllib.unquote(feed_json['id']))
 
         # Connects to WebView
         self.webview.connect('title-changed', title_changed)

--- a/Ubuntu/lightread/LightreadWindow.py
+++ b/Ubuntu/lightread/LightreadWindow.py
@@ -200,8 +200,6 @@ class LightreadWindow(Window):
                             self.set_title(title[1] + " - Lightread")
 
                         launcher.set_property("count", int(title[1]))
-                        # if self.indicator is not None:
-                        #     self.indicator.set_unread_count(int(title[1]))
                     except UnboundLocalError:
                         pass
 


### PR DESCRIPTION
Instead of displaying a single entry for lightread with all the unread counts, place an entry in the messaging menu for each unread feed with the feed name/count.

Update when the feed count refreshes.

Remove feeds with no unread posts.
