### PR TITLE
Changed colors so app isn't so Ubuntu-exclusive

### DIFF
--- a/App/css/style.css
+++ b/App/css/style.css
@@ -4,7 +4,7 @@ a:focus { outline: none; }
 
 ::-webkit-scrollbar { width: 5px; }
 
-::-webkit-scrollbar-thumb { background: #525252; }
+::-webkit-scrollbar-thumb { background: #858585; }
 
 #articles::-webkit-scroller-thumb { border-left: 1px solid #e1e1df; }
 
@@ -126,7 +126,7 @@ input, textarea { font-family: "Ubuntu", "Helvetica", "Arial", sans-serif; }
 #articles li header { display: -webkit-box; }
 #articles li header .icon { padding: 5px 4px 0 2px; }
 #articles li header .feed { font-size: 12px; color: #777777; line-height: 25px; -webkit-box-flex: 1; display: block; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
-#articles li header .time { display: block; line-height: 25px; font-size: 12px; margin-right: 2px; color: #525252; }
+#articles li header .time { display: block; line-height: 25px; font-size: 12px; margin-right: 2px; color: #858585; }
 #articles li .title { font-size: 13px; display: block; margin-top: -2px; padding: 0 0 2px 22px; font-weight: bold; color: #3b3b3b; text-shadow: 0 0 1px rgba(0, 0, 0, 0.01); }
 #articles li .snippet { display: block; padding: 0 0 0 22px; line-height: 16px; color: #888888; height: 34px; overflow: hidden; }
 #articles .splitter { height: 20px; padding-left: 10px; font-size: 13px; font-weight: bold; color: #666666; line-height: 20px; background: -webkit-linear-gradient(#fefefe, #fafafa); text-shadow: 0 1px 0 white; border: 1px solid #e1e1df; border-left: 0; border-right: 0; }

--- a/App/css/style.css
+++ b/App/css/style.css
@@ -4,7 +4,7 @@ a:focus { outline: none; }
 
 ::-webkit-scrollbar { width: 5px; }
 
-::-webkit-scrollbar-thumb { background: #f07746; }
+::-webkit-scrollbar-thumb { background: #525252; }
 
 #articles::-webkit-scroller-thumb { border-left: 1px solid #e1e1df; }
 
@@ -126,7 +126,7 @@ input, textarea { font-family: "Ubuntu", "Helvetica", "Arial", sans-serif; }
 #articles li header { display: -webkit-box; }
 #articles li header .icon { padding: 5px 4px 0 2px; }
 #articles li header .feed { font-size: 12px; color: #777777; line-height: 25px; -webkit-box-flex: 1; display: block; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
-#articles li header .time { display: block; line-height: 25px; font-size: 12px; margin-right: 2px; color: #f07746; }
+#articles li header .time { display: block; line-height: 25px; font-size: 12px; margin-right: 2px; color: #525252; }
 #articles li .title { font-size: 13px; display: block; margin-top: -2px; padding: 0 0 2px 22px; font-weight: bold; color: #3b3b3b; text-shadow: 0 0 1px rgba(0, 0, 0, 0.01); }
 #articles li .snippet { display: block; padding: 0 0 0 22px; line-height: 16px; color: #888888; height: 34px; overflow: hidden; }
 #articles .splitter { height: 20px; padding-left: 10px; font-size: 13px; font-weight: bold; color: #666666; line-height: 20px; background: -webkit-linear-gradient(#fefefe, #fafafa); text-shadow: 0 1px 0 white; border: 1px solid #e1e1df; border-left: 0; border-right: 0; }


### PR DESCRIPTION
Replaced instances of Ubuntu-like orange color (f07746) to a darker gray color already present in the app (525252) so that the application is relevant on non-Ubuntu themed distributions (such as elementaryOS)

I doubt that the two references I've replaced in this file are the only two in the application, but I merely wanted to propose the change. Obviously, I'd be willing to hunt down more and replace them if there were a multitude of people who think it is a good idea.

Alternatively, perhaps this could simply become a theme or mode (like the night mode already available in the Settings menu).

Thank you for your time.
