### PR TITLE
Remove launchpad gir dependency

### DIFF
--- a/Ubuntu/debian/changelog
+++ b/Ubuntu/debian/changelog
@@ -1,6 +1,11 @@
 lightread (1.2.2) precise; urgency=low
 
+  [ consindo ]
   * New release.
+
+  [ Dražen Lučanin ]
+  * Launchpad GIR as a suggested dependency
+    ( https://launchpad.net/ubuntu/raring/+source/launchpad-integration/0.1.56.2 ) 
 
  -- consindo <jono@caffeinatedco.de>  Fri, 05 Oct 2012 20:59:04 +1300
 

--- a/Ubuntu/debian/control
+++ b/Ubuntu/debian/control
@@ -22,7 +22,7 @@ Depends: ${misc:Depends},
  gir1.2-soup-2.4,
  python-xdg,
  gir1.2-webkit-3.0,
- gir1.2-launchpad-integration-3.0,
  yelp
+Suggests: gir1.2-launchpad-integration-3.0
 Description: A lightweight news reader.
  UNKNOWN


### PR DESCRIPTION
due to launchpad-integration being [removed from the Ubuntu repos](https://bugs.launchpad.net/ubuntu/+source/launchpad-integration/+bug/999413)
